### PR TITLE
v0.2.8: Fix doc links: wip-release and wip-file-guard now point to DevOps Toolbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 
 
+
+## 0.2.8 (2026-03-14)
+
+Fix doc links: wip-release and wip-file-guard now point to DevOps Toolbox
+
 ## 0.2.7 (2026-03-14)
 
 Add REFERENCE.md and SPEC.md to docs, fix installer references

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, skill]
 metadata:
   display-name: "LDM OS"
-  version: "0.2.7"
+  version: "0.2.8"
   homepage: "https://github.com/wipcomputer/wip-ldm-os"
   author: "Parker Todd Brooks"
   category: infrastructure

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -105,7 +105,7 @@ ldm install
 |------|------|------------|-------------|
 | [wip-grok](https://github.com/wipcomputer/wip-grok) | Sensor + Actuator | CLI + Module + MCP + Skill | xAI Grok API: search web/X, generate images/video |
 | [wip-x](https://github.com/wipcomputer/wip-x) | Sensor + Actuator | CLI + Module + MCP + Skill | X Platform API: read/write tweets, bookmarks |
-| [wip-file-guard](https://github.com/wipcomputer/wip-file-guard) | Actuator | CLI + OpenClaw + CC Hook | Protect files from AI edits |
+| [wip-file-guard](https://github.com/wipcomputer/wip-ai-devops-toolbox) | Actuator | CLI + OpenClaw + CC Hook | Protect files from AI edits |
 | [wip-healthcheck](https://github.com/wipcomputer/wip-healthcheck) | Sensor | CLI + Module | System health monitoring |
 
 ## Supported Tools

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -176,5 +176,5 @@ ldm install                        # update all
 |------|------------|------|
 | [wip-grok](https://github.com/wipcomputer/wip-grok) | CLI + Module + MCP + Skill | Sensor + Actuator |
 | [wip-x](https://github.com/wipcomputer/wip-x) | CLI + Module + MCP + Skill | Sensor + Actuator |
-| [wip-file-guard](https://github.com/wipcomputer/wip-file-guard) | CLI + OpenClaw + CC Hook | Actuator |
+| [wip-file-guard](https://github.com/wipcomputer/wip-ai-devops-toolbox) | CLI + OpenClaw + CC Hook | Actuator |
 | [wip-markdown-viewer](https://github.com/wipcomputer/wip-markdown-viewer) | CLI + Module | Actuator |

--- a/docs/universal-installer.md
+++ b/docs/universal-installer.md
@@ -61,9 +61,9 @@ Then ask me:
 
 Your agent will read the repo, explain the tool, and walk you through integration interactively.
 
-Also see **[wip-release](https://github.com/wipcomputer/wip-release)** ... one-command release pipeline for agent-native software.
+Also see **[wip-release](https://github.com/wipcomputer/wip-ai-devops-toolbox)** ... one-command release pipeline for agent-native software.
 
-Also see **[wip-file-guard](https://github.com/wipcomputer/wip-file-guard)** ... the lock for the repo. Blocks AI agents from overwriting your critical files.
+Also see **[wip-file-guard](https://github.com/wipcomputer/wip-ai-devops-toolbox)** ... the lock for the repo. Blocks AI agents from overwriting your critical files.
 
 See [REFERENCE.md](REFERENCE.md) for sensors/actuators, the interface table, how to build it, the installer, and real examples.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ldm-os",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "LDM OS: identity, memory, and sovereignty infrastructure for AI agents",
   "main": "src/boot/boot-hook.mjs",


### PR DESCRIPTION
Synced from private repo (commit abc1ce7).