### PR TITLE
v0.2.13: Fix: deploy guard.mjs to ~/.ldm/extensions/ before configuring CC hook. Hooks no longer point to /tmp/. Also adds ldm doctor --fix flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.2.13 (2026-03-14)
+
+Fix: deploy guard.mjs to ~/.ldm/extensions/ before configuring CC hook. Hooks no longer point to /tmp/. Also adds ldm doctor --fix flag.
+
 ## 0.2.12 (2026-03-14)
 
 Fix corrupted SKILL.md version string. Fix install prompt URLs to use wip- prefix.

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, skill]
 metadata:
   display-name: "LDM OS"
-  version: "0.2.12"
+  version: "0.2.13"
   homepage: "https://github.com/wipcomputer/wip-ldm-os"
   author: "Parker Todd Brooks"
   category: infrastructure

--- a/bin/ldm.js
+++ b/bin/ldm.js
@@ -46,6 +46,7 @@ const DRY_RUN = args.includes('--dry-run');
 const JSON_OUTPUT = args.includes('--json');
 const YES_FLAG = args.includes('--yes') || args.includes('-y');
 const NONE_FLAG = args.includes('--none');
+const FIX_FLAG = args.includes('--fix');
 
 function readJSON(path) {
   try {
@@ -606,10 +607,27 @@ async function cmdDoctor() {
   console.log(formatReconciliation(reconciled, { verbose: true }));
 
   // Count issues from reconciliation
-  for (const entry of Object.values(reconciled)) {
-    if (entry.status === 'registered-missing') issues++;
+  const registeredMissing = [];
+  for (const [name, entry] of Object.entries(reconciled)) {
+    if (entry.status === 'registered-missing') {
+      issues++;
+      registeredMissing.push(name);
+    }
     if (entry.issues.length > 0 && entry.status !== 'installed-unlinked' && entry.status !== 'external') {
       issues += entry.issues.length;
+    }
+  }
+
+  // --fix: clean up registered-missing entries
+  if (FIX_FLAG && registeredMissing.length > 0) {
+    const registry = readJSON(REGISTRY_PATH);
+    if (registry?.extensions) {
+      for (const name of registeredMissing) {
+        delete registry.extensions[name];
+        console.log(`  + Removed stale registry entry: ${name}`);
+        issues--;
+      }
+      writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2) + '\n');
     }
   }
 

--- a/lib/deploy.mjs
+++ b/lib/deploy.mjs
@@ -10,7 +10,7 @@
 
 import { execSync } from 'node:child_process';
 import {
-  existsSync, readFileSync, writeFileSync, cpSync, mkdirSync,
+  existsSync, readFileSync, writeFileSync, copyFileSync, cpSync, mkdirSync,
   lstatSync, readlinkSync, unlinkSync, chmodSync, readdirSync,
   renameSync, rmSync, statSync,
 } from 'node:fs';
@@ -523,10 +523,26 @@ function installClaudeCodeHook(repoPath, door) {
   }
 
   const toolName = basename(repoPath);
-  const installedGuard = join(LDM_EXTENSIONS, toolName, 'guard.mjs');
+  const extDir = join(LDM_EXTENSIONS, toolName);
+  const installedGuard = join(extDir, 'guard.mjs');
+
+  // Deploy guard.mjs to ~/.ldm/extensions/{toolName}/ if not already there
+  const srcGuard = join(repoPath, 'guard.mjs');
+  if (!existsSync(installedGuard) && existsSync(srcGuard)) {
+    try {
+      if (!existsSync(extDir)) mkdirSync(extDir, { recursive: true });
+      copyFileSync(srcGuard, installedGuard);
+      // Also copy package.json for metadata
+      const srcPkg = join(repoPath, 'package.json');
+      if (existsSync(srcPkg)) copyFileSync(srcPkg, join(extDir, 'package.json'));
+    } catch (e) {
+      // Non-fatal: fall back to source path
+    }
+  }
+
   const hookCommand = existsSync(installedGuard)
     ? `node ${installedGuard}`
-    : (door.command || `node "${join(repoPath, 'guard.mjs')}"`);
+    : (door.command || `node "${srcGuard}"`);
 
   if (DRY_RUN) {
     ok(`Claude Code: would add ${door.event || 'PreToolUse'} hook (dry run)`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ldm-os",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "LDM OS: identity, memory, and sovereignty infrastructure for AI agents",
   "main": "src/boot/boot-hook.mjs",


### PR DESCRIPTION
Synced from private repo (commit 7e9d9bd).