### PR TITLE
v0.2.14: Add .publish-skill.json. SKILL.md auto-publishes to wip.computer on release. Website was stuck at v0.2.5.

### DIFF
--- a/.publish-skill.json
+++ b/.publish-skill.json
@@ -1,0 +1,4 @@
+{
+  "name": "wip-ldm-os",
+  "websiteRepo": "/Users/lesa/Documents/wipcomputer--mac-mini-01/staff/Parker/Claude Code - Mini/repos/wip-web/wip-websites-private"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.2.14 (2026-03-14)
+
+Add .publish-skill.json. SKILL.md auto-publishes to wip.computer on release. Website was stuck at v0.2.5.
+
 ## 0.2.13 (2026-03-14)
 
 Fix: deploy guard.mjs to ~/.ldm/extensions/ before configuring CC hook. Hooks no longer point to /tmp/. Also adds ldm doctor --fix flag.

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, skill]
 metadata:
   display-name: "LDM OS"
-  version: "0.2.13"
+  version: "0.2.14"
   homepage: "https://github.com/wipcomputer/wip-ldm-os"
   author: "Parker Todd Brooks"
   category: infrastructure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ldm-os",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "description": "LDM OS: identity, memory, and sovereignty infrastructure for AI agents",
   "main": "src/boot/boot-hook.mjs",


### PR DESCRIPTION
Synced from private repo (commit 6ccd653).