### PR TITLE
v0.3.4: Fix: auto-sync version.json when CLI version drifts after npm upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.3.4 (2026-03-15)
+
+Fix: auto-sync version.json when CLI version drifts after npm upgrade
+
 ## 0.3.3 (2026-03-15)
 
 Fix: detect /tmp/ hook paths as stale even when file exists

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, skill]
 metadata:
   display-name: "LDM OS"
-  version: "0.3.3"
+  version: "0.3.4"
   homepage: "https://github.com/wipcomputer/wip-ldm-os"
   author: "Parker Todd Brooks"
   category: infrastructure

--- a/bin/ldm.js
+++ b/bin/ldm.js
@@ -45,6 +45,19 @@ try {
   CATALOG = JSON.parse(readFileSync(catalogPath, 'utf8'));
 } catch {}
 
+// Auto-sync version.json when CLI version drifts (#33)
+// npm install -g updates the binary but not version.json. Fix it on any CLI invocation.
+if (existsSync(VERSION_PATH)) {
+  try {
+    const v = JSON.parse(readFileSync(VERSION_PATH, 'utf8'));
+    if (v.version && v.version !== PKG_VERSION) {
+      v.version = PKG_VERSION;
+      v.updated = new Date().toISOString();
+      writeFileSync(VERSION_PATH, JSON.stringify(v, null, 2) + '\n');
+    }
+  } catch {}
+}
+
 const args = process.argv.slice(2);
 const command = args[0];
 const DRY_RUN = args.includes('--dry-run');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ldm-os",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "description": "LDM OS: identity, memory, and sovereignty infrastructure for AI agents",
   "main": "src/boot/boot-hook.mjs",


### PR DESCRIPTION
Synced from private repo (commit 62d6698).