### PR TITLE
v0.4.24: # Fix ldm install: CLIs, catalog fallback, /tmp/ symlinks, help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
 
+## 0.4.24 (2026-03-17)
+
+# Fix ldm install: CLIs, catalog fallback, /tmp/ symlinks, help
+
+Five interconnected bugs fixed in ldm install:
+
+1. **Global CLIs not updated (#81):** Added a second loop in `cmdInstallCatalog()` that checks `state.cliBinaries` against catalog `cliMatches`. CLIs installed via `npm install -g` are now detected and updated.
+
+2. **Catalog fallback (#82):** When no catalog entry matches an extension, falls back to `package.json` `repository.url` instead of skipping. Also added `wip-branch-guard` to catalog registryMatches/cliMatches.
+
+3. **/tmp/ symlink prevention (#32):** `installCLI()` in deploy.mjs now tries the latest npm version before falling back to local `npm install -g .`. This prevents /tmp/ symlinks in most cases.
+
+4. **/tmp/ cleanup (#32):** After `installFromPath()` completes, /tmp/ clones are deleted automatically.
+
+5. **--help flag:** `ldm install --help` now shows usage instead of triggering a real install.
+
+Closes #81, #82. Partial fix for #32.
+
 ## 0.4.23 (2026-03-17)
 
 # Fix ldm install: CLIs, catalog fallback, /tmp/ symlinks, help

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, skill]
 metadata:
   display-name: "LDM OS"
-  version: "0.4.23"
+  version: "0.4.24"
   homepage: "https://github.com/wipcomputer/wip-ldm-os"
   author: "Parker Todd Brooks"
   category: infrastructure

--- a/lib/deploy.mjs
+++ b/lib/deploy.mjs
@@ -683,7 +683,10 @@ export function installSingleTool(toolPath) {
 
   if (ifaceNames.length === 0) return 0;
 
-  const toolName = pkg?.name?.replace(/^@\w+\//, '') || basename(toolPath);
+  // Derive tool name from package.json, never from /tmp/ clone path
+  let toolName = pkg?.name?.replace(/^@\w+\//, '') || basename(toolPath);
+  // Strip ldm-install- prefix if it leaked from clone path
+  toolName = toolName.replace(/^ldm-install-/, '');
 
   // Migrate ldm-install-* ghost directories (#96)
   // Old installs used /tmp/ldm-install-<name> as source, which leaked into the directory name.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ldm-os",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "description": "LDM OS: identity, memory, and sovereignty infrastructure for AI agents",
   "main": "src/boot/boot-hook.mjs",


### PR DESCRIPTION
Synced from private repo (commit 5c4e7ea).