### PR TITLE
v0.4.25: # Fix ldm install: CLIs, catalog fallback, /tmp/ symlinks, help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
 
+## 0.4.25 (2026-03-17)
+
+# Fix ldm install: CLIs, catalog fallback, /tmp/ symlinks, help
+
+Five interconnected bugs fixed in ldm install:
+
+1. **Global CLIs not updated (#81):** Added a second loop in `cmdInstallCatalog()` that checks `state.cliBinaries` against catalog `cliMatches`. CLIs installed via `npm install -g` are now detected and updated.
+
+2. **Catalog fallback (#82):** When no catalog entry matches an extension, falls back to `package.json` `repository.url` instead of skipping. Also added `wip-branch-guard` to catalog registryMatches/cliMatches.
+
+3. **/tmp/ symlink prevention (#32):** `installCLI()` in deploy.mjs now tries the latest npm version before falling back to local `npm install -g .`. This prevents /tmp/ symlinks in most cases.
+
+4. **/tmp/ cleanup (#32):** After `installFromPath()` completes, /tmp/ clones are deleted automatically.
+
+5. **--help flag:** `ldm install --help` now shows usage instead of triggering a real install.
+
+Closes #81, #82. Partial fix for #32.
+
 ## 0.4.24 (2026-03-17)
 
 # Fix ldm install: CLIs, catalog fallback, /tmp/ symlinks, help

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, skill]
 metadata:
   display-name: "LDM OS"
-  version: "0.4.24"
+  version: "0.4.25"
   homepage: "https://github.com/wipcomputer/wip-ldm-os"
   author: "Parker Todd Brooks"
   category: infrastructure

--- a/bin/ldm.js
+++ b/bin/ldm.js
@@ -31,6 +31,17 @@ const LDM_EXTENSIONS = join(LDM_ROOT, 'extensions');
 const VERSION_PATH = join(LDM_ROOT, 'version.json');
 const REGISTRY_PATH = join(LDM_EXTENSIONS, 'registry.json');
 
+// Install log (#101): append to ~/.ldm/logs/install.log
+import { appendFileSync } from 'node:fs';
+const LOG_DIR = join(LDM_ROOT, 'logs');
+const LOG_PATH = join(LOG_DIR, 'install.log');
+function installLog(msg) {
+  try {
+    mkdirSync(LOG_DIR, { recursive: true });
+    appendFileSync(LOG_PATH, `[${new Date().toISOString()}] ${msg}\n`);
+  } catch {}
+}
+
 // Read our own version from package.json
 const pkgPath = join(__dirname, '..', 'package.json');
 let PKG_VERSION = '0.2.0';
@@ -654,6 +665,7 @@ function autoDetectExtensions() {
 
 async function cmdInstallCatalog() {
   // No lock here. cmdInstall() already holds it when calling this.
+  installLog(`ldm install started (v${PKG_VERSION}, DRY_RUN=${DRY_RUN})`);
 
   // Self-update: check if CLI itself is outdated. Update first, then re-exec.
   // This breaks the chicken-and-egg: new features in ldm install are always
@@ -1089,6 +1101,7 @@ async function cmdInstallCatalog() {
 
   console.log('');
   console.log(`  Updated ${updated}/${totalUpdates} extension(s).`);
+  installLog(`ldm install complete: ${updated}/${totalUpdates} updated, ${healthFixes} health fix(es)`);
 
   // Check if CLI itself is outdated (#29)
   checkCliVersion();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ldm-os",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "description": "LDM OS: identity, memory, and sovereignty infrastructure for AI agents",
   "main": "src/boot/boot-hook.mjs",


### PR DESCRIPTION
Synced from private repo (commit 17c9892).