### PR TITLE
v0.4.44: Fix the deploy bug. Every release since the Mar 24 migration silently failed to deploy the install skill to wip.computer because .publish-skill.json still pointed to the old iCloud path. wip-release copied the file to a path that didn't exist, said "deploy skipped," and moved on. The VPS stayed stale. We manually deployed three times today before finding the root cause.

### DIFF
--- a/.publish-skill.json
+++ b/.publish-skill.json
@@ -1,4 +1,4 @@
 {
   "name": "wip-ldm-os",
-  "websiteRepo": "/Users/lesa/Documents/wipcomputer--mac-mini-01/staff/Parker/Claude Code - Mini/repos/wip-web/wip-websites-private"
+  "websiteRepo": "/Users/lesa/wipcomputerinc/repos/wip-web/wip-websites-private"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 
+## 0.4.44 (2026-03-25)
+
+Fix the deploy bug. Every release since the Mar 24 migration silently failed to deploy the install skill to wip.computer because .publish-skill.json still pointed to the old iCloud path. wip-release copied the file to a path that didn't exist, said "deploy skipped," and moved on. The VPS stayed stale. We manually deployed three times today before finding the root cause.
+
+One-line fix: updated websiteRepo in .publish-skill.json from the old iCloud location to ~/wipcomputerinc/repos/wip-web/wip-websites-private. Now wip-release will find deploy.sh and auto-deploy the skill to wip.computer on every release.
+
+This is a symptom of the larger problem: hardcoded paths that break when the workspace moves. The real fix is reading websiteRepo from settings/config.json so there's one place to update. Filed #208 for that.
+
+Closes #208.
+
 ## 0.4.43 (2026-03-25)
 
 Every change flows through the repo and the installer. Never touch the running system directly.

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 interface: [cli, skill]
 metadata:
   display-name: "LDM OS"
-  version: "0.4.43"
+  version: "0.4.44"
   homepage: "https://github.com/wipcomputer/wip-ldm-os"
   author: "Parker Todd Brooks"
   category: infrastructure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wipcomputer/wip-ldm-os",
-  "version": "0.4.43",
+  "version": "0.4.44",
   "type": "module",
   "description": "LDM OS: identity, memory, and sovereignty infrastructure for AI agents",
   "engines": {


### PR DESCRIPTION
Synced from private repo (commit 15eecb0).